### PR TITLE
feat(cdp-analytics-node): add support Vercel Edge

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@customerio/cdp-analytics-core": "0.0.2",
+    "buffer": "^6.0.3",
     "node-fetch": "^2.6.7",
     "tslib": "^2.4.1",
     "uuid": "^9.0.0"

--- a/packages/node/src/lib/__tests__/env.test.ts
+++ b/packages/node/src/lib/__tests__/env.test.ts
@@ -5,6 +5,15 @@ afterEach(() => {
   process.env = ogProcess
   // @ts-ignore
   delete globalThis.window
+
+  // @ts-ignore
+  delete globalThis.WebSocketPair
+
+  // @ts-ignore
+  delete globalThis.EdgeRuntime
+
+  // @ts-ignore
+  delete globalThis.window
 })
 describe(detectRuntime, () => {
   it('should return web worker if correct env', () => {
@@ -39,5 +48,16 @@ describe(detectRuntime, () => {
     // @ts-ignore
     globalThis.WebSocketPair = {}
     expect(detectRuntime()).toEqual<RuntimeEnv>('cloudflare-worker')
+  })
+
+  it('should return edgeruntime if correct env', () => {
+    // @ts-ignore
+    // eslint-disable-next-line
+    delete process.env
+
+    // @ts-ignore
+    globalThis.EdgeRuntime = 'vercel'
+
+    expect(detectRuntime()).toEqual<RuntimeEnv>('vercel-edge')
   })
 })

--- a/packages/node/src/lib/abort.ts
+++ b/packages/node/src/lib/abort.ts
@@ -30,7 +30,7 @@ class AbortSignal {
     const handlerName = `on${type}`
 
     if (typeof (this as any)[handlerName] === 'function') {
-      ; (this as any)[handlerName](event)
+      ;(this as any)[handlerName](event)
     }
 
     this.eventEmitter.emit(type, event)
@@ -64,7 +64,7 @@ export const abortSignalAfterTimeout = (timeoutMs: number) => {
   if (detectRuntime() === 'cloudflare-worker') {
     return [] // TODO: this is broken in cloudflare workers, otherwise results in "A hanging Promise was canceled..." error.
   }
-  const ac = new (global.AbortController || AbortController)()
+  const ac = new (globalThis.AbortController || AbortController)()
 
   const timeoutId = setTimeout(() => {
     ac.abort()

--- a/packages/node/src/lib/base-64-encode.ts
+++ b/packages/node/src/lib/base-64-encode.ts
@@ -1,14 +1,8 @@
+import { Buffer } from 'buffer'
+/**
 /**
  * Base64 encoder that works in browser, worker, node runtimes.
  */
 export const b64encode = (str: string): string => {
-  if (
-    // in node env
-    typeof Buffer !== 'undefined'
-  ) {
-    return Buffer.from(str).toString('base64')
-  } else {
-    // in worker env
-    return btoa(str)
-  }
+  return Buffer.from(str).toString('base64')
 }

--- a/packages/node/src/lib/env.ts
+++ b/packages/node/src/lib/env.ts
@@ -3,6 +3,7 @@ export type RuntimeEnv =
   | 'browser'
   | 'web-worker'
   | 'cloudflare-worker'
+  | 'vercel-edge'
   | 'unknown'
 
 export const detectRuntime = (): RuntimeEnv => {
@@ -17,6 +18,11 @@ export const detectRuntime = (): RuntimeEnv => {
   // @ts-ignore
   if (typeof WebSocketPair !== 'undefined') {
     return 'cloudflare-worker'
+  }
+
+  // @ts-ignore
+  if (typeof EdgeRuntime === 'string') {
+    return 'vercel-edge'
   }
 
   if (

--- a/packages/node/src/lib/fetch.ts
+++ b/packages/node/src/lib/fetch.ts
@@ -1,3 +1,14 @@
-import { default as _fetch } from 'node-fetch'
-
-export const fetch = globalThis.fetch || _fetch
+export const fetch: typeof globalThis.fetch = async (...args) => {
+  if (globalThis.fetch) {
+    return globalThis.fetch(...args)
+  } // @ts-ignore
+  // This guard causes is important, as it causes dead-code elimination to be enabled inside this block.
+  else if (typeof EdgeRuntime !== 'string') {
+    // @ts-ignore
+    return (await import('node-fetch')).default(...args) as Response
+  } else {
+    throw new Error(
+      'Invariant: an edge runtime that does not support fetch should not exist'
+    )
+  }
+}

--- a/packages/node/src/plugins/customerio/index.ts
+++ b/packages/node/src/plugins/customerio/index.ts
@@ -10,7 +10,8 @@ function normalizeEvent(ctx: Context) {
   ctx.updateEvent('context.library.version', version)
   const runtime = detectRuntime()
   if (runtime === 'node') {
-    ctx.updateEvent('_metadata.nodeVersion', process.versions.node)
+    // eslint-disable-next-line no-restricted-globals
+    ctx.updateEvent('_metadata.nodeVersion', process.version)
   }
   ctx.updateEvent('_metadata.jsRuntime', runtime)
 }

--- a/packages/node/src/plugins/customerio/index.ts
+++ b/packages/node/src/plugins/customerio/index.ts
@@ -10,8 +10,10 @@ function normalizeEvent(ctx: Context) {
   ctx.updateEvent('context.library.version', version)
   const runtime = detectRuntime()
   if (runtime === 'node') {
-    // eslint-disable-next-line no-restricted-globals
-    ctx.updateEvent('_metadata.nodeVersion', process.version)
+    // extra guard here was important for vercel edge.
+    if (typeof process.versions === 'object') {
+      ctx.updateEvent('_metadata.nodeVersion', process.versions.node)
+    }
   }
   ctx.updateEvent('_metadata.jsRuntime', runtime)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,6 +825,7 @@ __metadata:
     "@internal/config": 0.0.0
     "@types/node": ^14
     "@types/uuid": ^9
+    buffer: ^6.0.3
     node-fetch: ^2.6.7
     tslib: ^2.4.1
     uuid: ^9.0.0
@@ -4554,6 +4555,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+  languageName: node
+  linkType: hard
+
 "bytes-iec@npm:^3.1.1":
   version: 3.1.1
   resolution: "bytes-iec@npm:3.1.1"
@@ -7225,7 +7236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e


### PR DESCRIPTION
This is porting [this PR from the upstream](https://github.com/segmentio/analytics-next/pull/813) in order to have this lib run fine in the Vercel Edge Runtime.

Indeed, we are currently in the process of moving from Segment to Customer.io DP and this is a blocker for us as all our tracking code is running on the Edge Runtime.
With the current version, there is no error whatsoever but events are never reaching customer.io 😭 