### PR TITLE
fix(vercel-edge): stop using the buffer package

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@customerio/cdp-analytics-core": "0.0.3",
-    "buffer": "^6.0.3",
     "node-fetch": "^2.6.7",
     "tslib": "^2.4.1",
     "uuid": "^9.0.0"

--- a/packages/node/src/lib/base-64-encode.ts
+++ b/packages/node/src/lib/base-64-encode.ts
@@ -1,8 +1,14 @@
-import { Buffer } from 'buffer'
-/**
 /**
  * Base64 encoder that works in browser, worker, node runtimes.
  */
 export const b64encode = (str: string): string => {
-  return Buffer.from(str).toString('base64')
+  if (
+    // in node env
+    typeof Buffer !== 'undefined'
+  ) {
+    return Buffer.from(str).toString('base64')
+  } else {
+    // in worker env
+    return btoa(str)
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,7 +826,6 @@ __metadata:
     "@internal/config": 0.0.0
     "@types/node": ^14
     "@types/uuid": ^9
-    buffer: ^6.0.3
     node-fetch: ^2.6.7
     tslib: ^2.4.1
     uuid: ^9.0.0
@@ -4572,16 +4571,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
-  languageName: node
-  linkType: hard
-
 "bytes-iec@npm:^3.1.1":
   version: 3.1.1
   resolution: "bytes-iec@npm:3.1.1"
@@ -7414,7 +7403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.1.13":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e


### PR DESCRIPTION
While porting https://github.com/segmentio/analytics-next/pull/813 in #8, I added the `buffer` package to avoid using the Node.js `buffer`  module.

However, it was a bad idea: on Node 18 (I don't know if it was different before), even if we have the `buffer` package in our `node_modules`, the Next.js compiler still thinks that we are using the built-in Node.js `buffer` module:
<img width="821" alt="image" src="https://github.com/customerio/cdp-analytics-js/assets/2678610/cceb58a6-9ce4-48a5-99f4-f6e48a0f4e67">

Therefore, this PR is just reverting this part of the change as the `btoa` function is indeed [compatible](https://nextjs.org/docs/pages/api-reference/edge#encoding-apis) with the Edge runtime.
![image](https://github.com/customerio/cdp-analytics-js/assets/2678610/4cf16e63-6789-4d7c-b9b3-47d4c1105722)
