### PR TITLE
Updated Regex & Test Cases

### DIFF
--- a/packages/browser/src/lib/__tests__/parse-cdn.test.ts
+++ b/packages/browser/src/lib/__tests__/parse-cdn.test.ts
@@ -42,14 +42,14 @@ beforeEach(async () => {
 
 it('detects the existing CDN', () => {
   withTag(`
-    <script src="https://cdp.customer.io/analytics.js/v1/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
+    <script src="https://cdp.customer.io/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
   `)
   expect(getCDN()).toMatchInlineSnapshot(`"https://cdp.customer.io"`)
 })
 
 it('should return the overridden cdn if window.analytics._cdn is mutated', () => {
   withTag(`
-  <script src="https://cdp.customer.io/analytics.js/v1/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
+  <script src="https://cdp.customer.io/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
   `)
     ; (window.analytics as any) = {
       _cdn: 'http://foo.cdn.com',
@@ -61,14 +61,14 @@ it('if analytics is not loaded yet, should still return cdn', () => {
   // is this an impossible state?
   window.analytics = undefined as any
   withTag(`
-  <script src="https://cdp.customer.io/analytics.js/v1/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
+  <script src="https://cdp.customer.io/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
   `)
   expect(getCDN()).toMatchInlineSnapshot(`"https://cdp.customer.io"`)
 })
 
 it('detects custom cdns that match in domain instrumentation patterns', () => {
   withTag(`
-    <script src="https://my.cdn.domain/analytics.js/v1/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
+    <script src="https://my.cdn.domain/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
   `)
   expect(getCDN()).toMatchInlineSnapshot(`"https://my.cdn.domain"`)
 })

--- a/packages/browser/src/lib/parse-cdn.ts
+++ b/packages/browser/src/lib/parse-cdn.ts
@@ -1,7 +1,8 @@
 import { embeddedWriteKey } from './embedded-write-key'
 
 const analyticsScriptRegex =
-  /(https:\/\/.*)\/analytics\.js\/v1\/(?:.*?)\/(?:platform|analytics.*)?/
+  /(https:\/\/[\w.-]+)\/(?:analytics\.js\/v1|v1\/analytics-js\/snippet)\/[\w-]+\/(analytics\.(?:min)\.js)/
+
 const getCDNUrlFromScriptTag = (): string | undefined => {
   let cdn: string | undefined
   const scripts = Array.prototype.slice.call(


### PR DESCRIPTION
In this commit I updated the regex, the previous regex was taking from `segement` and did not take into account the format of the filename that we served on edge I also updated the test cases.

It is documented https://customer.io/docs/cdp/sources/connections/javascript/js-source-proxy/#client-side-javascript-snippet, That we serve the url like this

```
- t.src="https://cdp.customer.io/v1/analytics-js/snippet/" + key + "/analytics.min.js"
+ t.src="https://<YOUR-PROXY-HOST>/v1/analytics-js/snippet/" + key + "/analytics.min.js"
``` 

previous regex was supporting
```
https://cdp.customer.io/analytics.js/v1/+ key +/analytics.min.js
``` 

