### PR TITLE
Handle analytics:track events from Gist

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
     "@segment/tsub": "1.0.1",
-    "customerio-gist-web": "^3.7.3",
+    "customerio-gist-web": "^3.9.0",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
@@ -8,6 +8,7 @@ describe('Customer.io In-App Plugin', () => {
   let analytics: Analytics
   let gistMessageShown: Function
   let gistMessageAction: Function
+  let gistEventDispatched: Function
 
   beforeEach(async () => {
     if(typeof analytics !== 'undefined') {
@@ -27,6 +28,8 @@ describe('Customer.io In-App Plugin', () => {
           gistMessageShown = cb
         } else if(name === 'messageAction') {
           gistMessageAction = cb
+        } else if(name === 'eventDispatched') {
+          gistEventDispatched = cb
         }
       },
       off: jest.fn(),
@@ -128,4 +131,21 @@ describe('Customer.io In-App Plugin', () => {
     expect(spy).toHaveBeenCalledTimes(0)
   })
 
+  it('should trigger journeys event for analytics:track', async () => {
+    const spy = jest.spyOn(analytics, 'track')
+    gistEventDispatched({
+      name: 'analytics:track',
+      payload: {
+        event: 'test-event',
+        properties: {
+          attr1: 'val1',
+          attr2: 'val2',
+        },
+      },
+    })
+    expect(spy).toBeCalledWith('test-event', {
+      attr1: 'val1',
+      attr2: 'val2',
+    }, undefined)
+  })
 })

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -78,6 +78,16 @@ export function InAppPlugin(
                 }
              }));
         });
+
+        Gist.events.on('eventDispatched', (gistEvent: any) => {
+            if(gistEvent.name == 'analytics:track') {
+                const trackEventName:string = gistEvent.payload?.event;
+                if(typeof trackEventName === 'undefined' || trackEventName == '') {
+                    return;
+                }
+                _analytics.track(trackEventName, gistEvent.payload?.properties, gistEvent.payload?.options);
+            }
+        });
     }
 
     async function page(ctx: Context): Promise<Context> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: ^3.7.3
+    customerio-gist-web: ^3.9.0
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5320,13 +5320,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:^3.7.3":
-  version: 3.7.3
-  resolution: "customerio-gist-web@npm:3.7.3"
+"customerio-gist-web@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "customerio-gist-web@npm:3.9.0"
   dependencies:
     axios: ^0.21.1
     uuid: ^8.3.2
-  checksum: cb898f8324809214b45a0f2c39f4c45fb568f2d0787ababcbc9f3e339d6f6a80c8bd354ebaf6079a7283ba15c6c529eaae0d25ea7cc1df58746fe3daf177b021
+  checksum: 99a2c19ff5447cd79aa9af804cf5812e29b856d208a810420700ca5ba038ec799b9754790e8e324186cf8585c6c4d617ba4c7f0c3b8c34cb355736a588caa453
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This lets customers make custom `analytics.track()` calls from HTML in-apps.