### PR TITLE
chore: export InAppPlugin

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -7,4 +7,6 @@ export * from './core/events'
 export * from './core/plugin'
 export * from './core/user'
 
+export * from './plugins/in-app-plugin'
+
 export type { AnalyticsSnippet } from './browser/standalone-analytics'


### PR DESCRIPTION
We are using customer.io extensively, however, we route most events through an intermediary called Jitsu first.
Jitsu also ships the ingested events to a ClickHouse server for analysis, similarly to Segment and Data Pipelines. 
As Jitsu is our main ingestion engine, we are using `getanalytics` and a companion plugin to route the events.

We now want to also use the In-App messages feature from customer.io. In order not to duplicate the plugin and GIST code, I'd love to just get the plugin as an export from the `@customerio/cdp-analytics-browser` package.

This change exports that particular plugin for use without the default customer.io Analytics Instance.