### PR TITLE
detect custom cdns if there's a `:` in write key

### DIFF
--- a/packages/browser/src/lib/__tests__/parse-cdn.test.ts
+++ b/packages/browser/src/lib/__tests__/parse-cdn.test.ts
@@ -24,7 +24,7 @@ function withTag(tag: string) {
 
   const documentSpy = jest.spyOn(global, 'document', 'get')
 
-  jest.spyOn(console, 'warn').mockImplementationOnce(() => { })
+  jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
 
   windowSpy.mockImplementation(() => {
     return jsd.window as unknown as Window & typeof globalThis
@@ -51,9 +51,9 @@ it('should return the overridden cdn if window.analytics._cdn is mutated', () =>
   withTag(`
   <script src="https://cdp.customer.io/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
   `)
-    ; (window.analytics as any) = {
-      _cdn: 'http://foo.cdn.com',
-    }
+  ;(window.analytics as any) = {
+    _cdn: 'http://foo.cdn.com',
+  }
   expect(getCDN()).toMatchInlineSnapshot(`"http://foo.cdn.com"`)
 })
 
@@ -69,6 +69,13 @@ it('if analytics is not loaded yet, should still return cdn', () => {
 it('detects custom cdns that match in domain instrumentation patterns', () => {
   withTag(`
     <script src="https://my.cdn.domain/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZvCF6czfBcfzNO6/analytics.min.js" />
+  `)
+  expect(getCDN()).toMatchInlineSnapshot(`"https://my.cdn.domain"`)
+})
+
+it('detects custom cdns if the write key has : in it', () => {
+  withTag(`
+    <script src="https://my.cdn.domain/v1/analytics-js/snippet/gA5MBlJXrtZaB5sMMZv:CF6czfBcfzNO6/analytics.min.js" />
   `)
   expect(getCDN()).toMatchInlineSnapshot(`"https://my.cdn.domain"`)
 })

--- a/packages/browser/src/lib/parse-cdn.ts
+++ b/packages/browser/src/lib/parse-cdn.ts
@@ -1,7 +1,7 @@
 import { embeddedWriteKey } from './embedded-write-key'
 
 const analyticsScriptRegex =
-  /(https:\/\/[\w.-]+)\/(?:analytics\.js\/v1|v1\/analytics-js\/snippet)\/[\w-]+\/(analytics\.(?:min)\.js)/
+  /(https:\/\/[\w.-]+)\/(?:analytics\.js\/v1|v1\/analytics-js\/snippet)\/[\w-:]+\/(analytics\.(?:min)\.js)/
 
 const getCDNUrlFromScriptTag = (): string | undefined => {
   let cdn: string | undefined


### PR DESCRIPTION
No prod impact. More of a local dev happiness. If the write key had a `:`, it was failing the regex check. 

PS: We shouldn't be doing regex, its not [licensed](https://regexlicensing.org/). 😛 