### PR TITLE
Update gist-web to latest release

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
     "@segment/tsub": "1.0.1",
-    "customerio-gist-web": "^3.11.3",
+    "customerio-gist-web": "^3.12.0",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: ^3.11.3
+    customerio-gist-web: ^3.12.0
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5323,13 +5323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:^3.11.3":
-  version: 3.11.3
-  resolution: "customerio-gist-web@npm:3.11.3"
+"customerio-gist-web@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "customerio-gist-web@npm:3.12.0"
   dependencies:
     axios: ^0.28.1
     uuid: ^8.3.2
-  checksum: c72ce67485716549201b9f71d4466e49658259bbee75b1bb626bbd54efdb974336b2cae11b3e98e73aed6cdaa5745b169a36e2ec725c75a326a5859aff40629a
+  checksum: 726e07d8769d0ad51d9600156a2a1bee95c90d133ee14acde1cfbca9ab93d190fea334da152b8dade917d3bf2e06e9e5339a0c91cca8a9afeb687cb4721e6fba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Linear issue: https://linear.app/customerio/issue/INAPP-12777/request-header-too-large-preventing-in-app-messages-from-rendering

Related PR: https://github.com/customerio/gist-web/pull/73