### PR TITLE
Add mise config and pin node

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+[env]
+# Needed because on macOS there are no prebuilt binaries for Node <15. Requires mise 2024.12.7+.
+MISE_ARCH="x86_64"
+
+[tools]
+node = "14.21.3"


### PR DESCRIPTION
Note that I targeted node 14.21.3 via rosetta on the Mac because there are no prebuilt binaries, and indeed Node 14.21.3 does not even build cleanly (at least in my Mac)