### PR TITLE
Rename segment analytics key dataset

### DIFF
--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -57,9 +57,9 @@ async function attempt<T>(promise: () => Promise<T>) {
 
 const globalAnalyticsKey = (
   document.querySelector(
-    'script[data-global-segment-analytics-key]'
+    'script[data-global-customerio-analytics-key]'
   ) as HTMLScriptElement
-)?.dataset.globalSegmentAnalyticsKey
+)?.dataset.globalCustomerioAnalyticsKey
 
 if (globalAnalyticsKey) {
   setGlobalAnalyticsKey(globalAnalyticsKey)


### PR DESCRIPTION
This is needed to be able to load both Segment and Customer.io snippets in the same page and not have them conflict on the detected write key.