### PR TITLE
Fix CDN selection when analytics key is renamed

### DIFF
--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -2,6 +2,17 @@
 import { getCDN, setGlobalCDNUrl } from '../lib/parse-cdn'
 import { setVersionType } from '../plugins/customerio/normalize'
 
+// The global analytics key must be set first so that subsequent calls to getCdn() fetch the CDN from the correct instance.
+const globalAnalyticsKey = (
+  document.querySelector(
+    'script[data-global-customerio-analytics-key]'
+  ) as HTMLScriptElement
+)?.dataset.globalCustomerioAnalyticsKey
+
+if (globalAnalyticsKey) {
+  setGlobalAnalyticsKey(globalAnalyticsKey)
+}
+
 if (process.env.ASSET_PATH) {
   if (process.env.ASSET_PATH === '/dist/umd/') {
     // @ts-ignore
@@ -53,16 +64,6 @@ async function attempt<T>(promise: () => Promise<T>) {
   } catch (err) {
     onError(err)
   }
-}
-
-const globalAnalyticsKey = (
-  document.querySelector(
-    'script[data-global-customerio-analytics-key]'
-  ) as HTMLScriptElement
-)?.dataset.globalCustomerioAnalyticsKey
-
-if (globalAnalyticsKey) {
-  setGlobalAnalyticsKey(globalAnalyticsKey)
 }
 
 if (shouldPolyfill()) {

--- a/packages/browser/src/lib/parse-cdn.ts
+++ b/packages/browser/src/lib/parse-cdn.ts
@@ -9,14 +9,19 @@ const getCDNUrlFromScriptTag = (): string | undefined => {
   const scripts = Array.prototype.slice.call(
     document.querySelectorAll('script')
   )
-  scripts.forEach((s) => {
+  for (const s of scripts) {
     const src = s.getAttribute('src') ?? ''
     const result = analyticsScriptRegex.exec(src)
 
     if (result && result[1]) {
       cdn = result[1]
     }
-  })
+
+    // If the script tag has the globalCustomerioAnalyticsKey attribute, then this is a CDP script (not segment).
+    if (s.dataset?.globalCustomerioAnalyticsKey != null) {
+      break
+    }
+  }
   return cdn
 }
 


### PR DESCRIPTION
Fixes the CDN selection by doing two things:
1. Load the alternate analytics key, if available.
2. If an alternate analytics key exists, pick the script from the DOM that contains it.