### PR TITLE
INAPP-13325 - Add message visible event tracking for in-app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable --mode=skip-build
 
       - name: Run Tests
         run: |

--- a/packages/browser/src/plugins/in-app-plugin/events.ts
+++ b/packages/browser/src/plugins/in-app-plugin/events.ts
@@ -2,7 +2,8 @@ export enum InAppEvents {
     MessageOpened = 'in-app:message-opened',
     MessageDismissed =  'in-app:message-dismissed',
     MessageError = 'in-app:message-error',
-    MessageAction = 'in-app:message-action'
+    MessageAction = 'in-app:message-action',
+    MessageVisible = 'in-app:message-visible'
 }
 
 export const allEvents:string[] = Object.values(InAppEvents);
@@ -32,6 +33,8 @@ export function gistToCIO(gistEvent:string): string {
             return InAppEvents.MessageError;
         case 'messageAction':
             return InAppEvents.MessageAction;
+        case 'messageVisible':
+            return InAppEvents.MessageVisible;
         default:
             return "";
     }


### PR DESCRIPTION
This makes it so we can see an event when a user is shown the second/third/fourth/nth message of a multi-screen in-app message. In the activity log it looks like this:

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/e0b958c1-3893-4cfb-8bfe-65d774a27536" />

The actionName is the message that was shown. Sometime in the future we will probably update the activity log to show a better title for these events.

This PR depends on https://github.com/customerio/gist-web-renderer/pull/27 being merged before we will start seeing these events.

I also updated the test gha because it was failing on the cache step after tests successfully passed. 
- Update: it turns out I had an outdated gha, but I'm still leaving the new changes since it makes the test job faster and does not install and build unused binaries