### PR TITLE
CDP-4574: Upgrade axios to v1.8.2 for security and compatibility

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,9 @@
 [env]
-MISE_FETCH_REMOTE_VERSIONS_TIMEOUT = '30s'
+MISE_FETCH_REMOTE_VERSIONS_TIMEOUT = "30s"
+# Needed because on macOS there are no prebuilt binaries for Node <15. Requires mise 2024.12.7+.
+MISE_ARCH="x86_64"
 
 [tools]
 node = "18.19.0"
-yarn = '3.2.1'
+yarn = "3.2.1"
 python = "3.11"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [env]
-# Needed because on macOS there are no prebuilt binaries for Node <15. Requires mise 2024.12.7+.
-MISE_ARCH="x86_64"
+MISE_FETCH_REMOTE_VERSIONS_TIMEOUT = '30s'
 
 [tools]
-node = "14.21.3"
+node = "18.19.0"
+yarn = '3.2.1'
+python = "3.11"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,0 @@
-[env]
-MISE_FETCH_REMOTE_VERSIONS_TIMEOUT = '30s'
-
-[tools]
-node = '14.7.3'
-yarn = '3.2.1'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": "^14.15.0"
+    "node": "^18.19.0"
   },
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "resolutions": {
     "@customerio/cdp-analytics-browser": "workspace:*",
     "@customerio/cdp-analytics-node": "workspace:*",
-    "@customerio/cdp-analytics-core": "workspace:*"
+    "@customerio/cdp-analytics-core": "workspace:*",
+    "axios": "1.8.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4451,22 +4451,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "axios@npm:0.25.0"
+"axios@npm:1.8.2":
+  version: 1.8.2
+  resolution: "axios@npm:1.8.2"
   dependencies:
-    follow-redirects: ^1.14.7
-  checksum: 2a8a3787c05f2a0c9c3878f49782357e2a9f38945b93018fb0c4fd788171c43dceefbb577988628e09fea53952744d1ecebde234b561f1e703aa43e0a598a3ad
-  languageName: node
-  linkType: hard
-
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
-  dependencies:
-    follow-redirects: ^1.14.9
+    follow-redirects: ^1.15.6
     form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+    proxy-from-env: ^1.1.0
+  checksum: c47a43b79a058aa9e53a65bec9ade35c9f6e76a3999c795a79a2d205fb5f803fd4245497a0209a9727cbbe4f558791dd852ad2c168c5fc030259c11598ed8fd7
   languageName: node
   linkType: hard
 
@@ -6703,7 +6695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.0.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -6713,13 +6705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.7":
-  version: 1.15.1
-  resolution: "follow-redirects@npm:1.15.1"
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.9
+  resolution: "follow-redirects@npm:1.15.9"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
+  checksum: 859e2bacc7a54506f2bf9aacb10d165df78c8c1b0ceb8023f966621b233717dab56e8d08baadc3ad3b9db58af290413d585c999694b7c146aaf2616340c3d2a6
   languageName: node
   linkType: hard
 
@@ -10372,7 +10364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:1.1.0":
+"proxy-from-env@npm:1.1.0, proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4


### PR DESCRIPTION
Upgrades Axios to version 1.8.2 (from v0.25.0/v0.27.2) to resolve known security vulnerabilities and enhance compatibility. This major update includes critical security patches, modern HTTP client improvements, and bug fixes. Related dependencies, such as follow-redirects, are also updated to align with current security standards and best practices.
Before
```
sydneycollins@Sydney-Wisdom-Collins cdp-analytics-js % yarn why axios   
├─ analytics-node@npm:6.2.0
│  └─ axios@npm:0.27.2 (via npm:^0.27.2)
│
└─ wait-on@npm:6.0.1
   └─ axios@npm:0.25.0 (via npm:^0.25.0)
``` 
After
```
sydneycollins@Sydney-Wisdom-Collins cdp-analytics-js % yarn why axios                         
├─ analytics-node@npm:6.2.0
│  └─ axios@npm:1.8.2 (via npm:1.8.2)
│
└─ wait-on@npm:6.0.1
   └─ axios@npm:1.8.2 (via npm:1.8.2)
``` 