### PR TITLE
Add flush method

### DIFF
--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -70,6 +70,14 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
   }
 
   /**
+   * Instantly flush any queued events, if there are any.
+   * @returns a promise resolving after the batch request has been successfully sent.
+   */
+  public flush(): Promise<void> {
+    return this._publisher.flush()
+  }
+
+  /**
    * Call this method to stop collecting new events and flush all existing events.
    * This method also waits for any event method-specific callbacks to be triggered,
    * and any of their subsequent promises to be resolved/rejected.

--- a/packages/node/src/plugins/customerio/publisher.ts
+++ b/packages/node/src/plugins/customerio/publisher.ts
@@ -12,7 +12,7 @@ function sleep(timeoutInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutInMs))
 }
 
-function noop() { }
+function noop() {}
 
 interface PendingItem {
   resolver: (ctx: Context) => void
@@ -87,6 +87,23 @@ export class Publisher {
   private clearBatch() {
     this.pendingFlushTimeout && clearTimeout(this.pendingFlushTimeout)
     this._batch = undefined
+  }
+
+  /**
+   * Instantly flush any queued events, if there are any.
+   * @returns a promise resolving after the batch request has been successfully sent.
+   */
+  async flush(): Promise<void> {
+    const batch = this._batch
+
+    if (!batch || batch.length === 0) {
+      return
+    }
+
+    const resultPromise = this.send(batch)
+    this.clearBatch()
+    // If the send request fails, the caller will throw when "awaiting" this returned promise
+    return resultPromise
   }
 
   flushAfterClose(pendingItemsCount: number) {


### PR DESCRIPTION
Not sure if you guys accept public pull requests, but no one is able to file issues so I thought a pull request might help speed the process along. I'm thinking about migrating to customer.io so I'm doing some initial research on the library support.

### Issue
The `flush()` method does not exist as documented in the [customer.io docs](https://docs.customer.io/integrations/data-in/connections/servers/node/#flush-events-on-demand). Not sure if this is just on the backlog still or was missed, but it is currently documented so I would call this a bug in the documentation or the library.

### Solution
I did this fairly quickly so it may be naive, as there is some fairly complex queue/emitter stuff going on I don't 100% understand. Let me know what you think, and if this public PRs are helpful or just annoying.

### Other thoughts
- It would be great if we could file issues against the code directly instead of routing it through support, which in my opinion just adds an unnecessary, non-technical middleman, but maybe it's important to your internal process.
- The current supported Node version is `v14.21.3` (in the mise.toml file, and I think some of the tests are failing locally on my local version - 22). You probably already know but v14 is marked as [end of life](https://nodejs.org/en/about/previous-releases) (since 2023). What are the current supported versions - will this work for example with v21/22?
- I haven't added tests yet as I am not familiar with the codebase
