### PR TITLE
fix: timeout hanging plugin.load() calls to prevent SDK deadlock

### DIFF
--- a/packages/core/src/queue/__tests__/event-queue.test.ts
+++ b/packages/core/src/queue/__tests__/event-queue.test.ts
@@ -638,6 +638,82 @@ describe('deregister', () => {
   })
 })
 
+describe('register plugin timeout', () => {
+  beforeEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('times out a destination plugin whose load() never resolves and adds it to failedInitializations', async () => {
+    const eq = new TestEventQueue()
+    const hangingPlugin: CorePlugin = {
+      name: 'Hanging Destination',
+      type: 'destination',
+      version: '0.1.0',
+      load: () => new Promise<void>(() => {}), // never resolves
+      isLoaded: () => false,
+    }
+
+    // Use pTimeout to ensure the test itself does not hang
+    await pTimeout(eq.register(TestCtx.system(), hangingPlugin, ajs), 15000)
+
+    // The plugin should NOT be in the plugins list
+    expect(eq.plugins.find((p) => p.name === 'Hanging Destination')).toBeUndefined()
+
+    // It should be recorded as a failed initialization
+    expect(eq.failedInitializations).toContain('Hanging Destination')
+  }, 20000)
+
+  it('throws for non-destination plugins whose load() never resolves', async () => {
+    const eq = new TestEventQueue()
+    const hangingPlugin: CorePlugin = {
+      name: 'Hanging Before Plugin',
+      type: 'before',
+      version: '0.1.0',
+      load: () => new Promise<void>(() => {}), // never resolves
+      isLoaded: () => false,
+    }
+
+    await expect(
+      pTimeout(eq.register(TestCtx.system(), hangingPlugin, ajs), 15000)
+    ).rejects.toThrow('Promise timed out')
+
+    // The plugin should NOT be in the plugins list
+    expect(eq.plugins.find((p) => p.name === 'Hanging Before Plugin')).toBeUndefined()
+  }, 20000)
+
+  it('continues initialization with other plugins after a destination plugin times out', async () => {
+    const eq = new TestEventQueue()
+    const hangingPlugin: CorePlugin = {
+      name: 'Hanging Destination',
+      type: 'destination',
+      version: '0.1.0',
+      load: () => new Promise<void>(() => {}), // never resolves
+      isLoaded: () => false,
+    }
+
+    const goodPlugin: CorePlugin = {
+      name: 'Good Plugin',
+      type: 'destination',
+      version: '0.1.0',
+      load: () => Promise.resolve(),
+      isLoaded: () => true,
+    }
+
+    // Register the good plugin first (resolves immediately)
+    await eq.register(TestCtx.system(), goodPlugin, ajs)
+
+    // Now register the hanging plugin — it will time out after 10s
+    await pTimeout(eq.register(TestCtx.system(), hangingPlugin, ajs), 15000)
+
+    // Good plugin should be registered
+    expect(eq.plugins.find((p) => p.name === 'Good Plugin')).toBeDefined()
+
+    // Hanging plugin should have failed
+    expect(eq.failedInitializations).toContain('Hanging Destination')
+    expect(eq.plugins.find((p) => p.name === 'Hanging Destination')).toBeUndefined()
+  }, 20000)
+})
+
 describe('dispatchSingle', () => {
   it('dispatches events without placing them on the queue', async () => {
     const eq = new TestEventQueue()

--- a/packages/core/src/queue/event-queue.ts
+++ b/packages/core/src/queue/event-queue.ts
@@ -8,6 +8,7 @@ import { Integrations, JSONObject } from '../events/interfaces'
 import { CorePlugin } from '../plugins'
 import { createTaskGroup, TaskGroup } from '../task/task-group'
 import { attempt, ensure } from './delivery'
+import { pTimeout } from '../callback'
 import { isOffline } from '../connection'
 
 export type EventQueueEmitterContract<Ctx extends CoreContext> = {
@@ -50,7 +51,7 @@ export abstract class CoreEventQueue<
     plugin: Plugin,
     instance: CoreAnalytics
   ): Promise<void> {
-    await Promise.resolve(plugin.load(ctx, instance))
+    await pTimeout(Promise.resolve(plugin.load(ctx, instance)), 10000)
       .then(() => {
         this.plugins.push(plugin)
       })


### PR DESCRIPTION
## Summary

- Wraps `plugin.load()` in `register()` with a 10-second `pTimeout` to prevent the SDK from hanging indefinitely when a remote plugin's `load()` never resolves (CDP-5711)
- Uses the existing `pTimeout` utility from `packages/core/src/callback/index.ts` -- no new dependencies
- Timeout errors flow through the existing catch block: destination plugins are gracefully added to `failedInitializations`, while non-destination plugin failures propagate up (matching existing behavior for load errors)

## Root Cause

In `packages/core/src/queue/event-queue.ts`, the `register()` method awaited `plugin.load()` with no timeout. If a remote destination plugin returned a promise that never resolved, `analytics.register()` would hang forever, blocking the SDK's ready state and causing all buffered events to never flush.

## Test plan

- [x] Added test: destination plugin whose `load()` never resolves gets timed out and added to `failedInitializations`
- [x] Added test: non-destination plugin whose `load()` never resolves throws `Promise timed out`
- [x] Added test: SDK continues initialization with other plugins after a destination plugin times out
- [x] All 3 new tests pass (`yarn jest --testPathPattern="queue/__tests__/event-queue" -t "register plugin timeout"`)

Fixes CDP-5711

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core plugin initialization: introducing a hard 10s timeout could cause slow-but-valid plugin loads to be treated as failures, altering SDK readiness and destination availability.
> 
> **Overview**
> Prevents SDK deadlock by wrapping `CoreEventQueue.register()`’s `plugin.load()` in a 10s `pTimeout`; timed-out/failed *destination* plugins are recorded in `failedInitializations` and skipped, while non-destination timeouts still propagate as errors.
> 
> Adds Jest coverage for hanging `load()` promises, verifying destinations fail gracefully without blocking other plugin registrations, and that non-destination plugins throw on timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e998645e527dfb2e0f7aa5068a701c6a3a7c2eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->