### PR TITLE
chore: bump gist-web to 3.21.15

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.21.13",
+    "customerio-gist-web": "3.21.15",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.21.13
+    customerio-gist-web: 3.21.15
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5632,12 +5632,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.21.13":
-  version: 3.21.13
-  resolution: "customerio-gist-web@npm:3.21.13"
+"customerio-gist-web@npm:3.21.15":
+  version: 3.21.15
+  resolution: "customerio-gist-web@npm:3.21.15"
   dependencies:
     uuid: ^8.3.2
-  checksum: 70ca761f1b032fc3ec69faed6f39e8e990edb62e0bd6cf6260b2db0c7fddca85c0a94b9f166ba91cdf0c0111ebca84cc86487f3752ca4f8511f3f244d9f4a9de
+  checksum: 0bed79b900ca97c5cebc1ed99cd5599d08c9ca9ddd91356116acd2ef3ff69a6352255f44a0e2b1312c898de6adbd7bd4afa1ca36137bdb11153ab14179bb4a6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.21.15](https://github.com/customerio/gist-web/releases/tag/3.21.15).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump; behavior changes, if any, come solely from the updated `customerio-gist-web` package.
> 
> **Overview**
> Updates the browser package’s `customerio-gist-web` dependency from `3.21.13` to `3.21.15`, with the corresponding `yarn.lock` resolution/checksum changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8dcfeeba5394b3087f2528b67000ee43a0a8289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->