### PR TITLE
Allow explicit disable of in-app plugin

### DIFF
--- a/packages/browser/src/browser/__tests__/in-app-plugin-integrations.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/in-app-plugin-integrations.integration.test.ts
@@ -1,0 +1,75 @@
+import unfetch from 'unfetch'
+import Gist from 'customerio-gist-web'
+import { AnalyticsBrowser } from '..'
+import { createSuccess } from '../../test-helpers/factories'
+
+jest.mock('unfetch')
+
+const inAppPluginName = 'Customer.io In-App Plugin'
+
+const mockCdnWithInAppPlugin = () => {
+  return jest.mocked(unfetch).mockImplementation(() =>
+    createSuccess({
+      integrations: {
+        [inAppPluginName]: { siteId: 'cdn-site-id' },
+      },
+    })
+  )
+}
+
+beforeEach(() => {
+  mockCdnWithInAppPlugin()
+  Gist.setup = jest.fn()
+  Gist.clearUserToken = jest.fn()
+  Gist.setUserToken = jest.fn()
+  Gist.setCurrentRoute = jest.fn()
+  Gist.setCustomAttribute = jest.fn()
+  Gist.clearCustomAttributes = jest.fn()
+  Gist.events = {
+    on: jest.fn(),
+    off: jest.fn(),
+    dispatch: jest.fn(),
+  } as unknown as typeof Gist.events
+})
+
+describe('In-App Plugin integrations option', () => {
+  it('registers the In-App Plugin when CDN settings include it', async () => {
+    const [analytics] = await AnalyticsBrowser.load({ writeKey: 'foo' })
+
+    const inApp = analytics.queue.plugins.find(
+      (p) => p.name === inAppPluginName
+    )
+    expect(inApp).toBeDefined()
+    expect(Gist.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: 'cdn-site-id' })
+    )
+  })
+
+  it('does not register the In-App Plugin when integrations sets it to false', async () => {
+    const [analytics] = await AnalyticsBrowser.load(
+      { writeKey: 'foo' },
+      { integrations: { [inAppPluginName]: false } }
+    )
+
+    const inApp = analytics.queue.plugins.find(
+      (p) => p.name === inAppPluginName
+    )
+    expect(inApp).toBeUndefined()
+    expect(Gist.setup).not.toHaveBeenCalled()
+  })
+
+  it('overrides CDN settings when integrations supplies an object', async () => {
+    const [analytics] = await AnalyticsBrowser.load(
+      { writeKey: 'foo' },
+      { integrations: { [inAppPluginName]: { siteId: 'override-site-id' } } }
+    )
+
+    const inApp = analytics.queue.plugins.find(
+      (p) => p.name === inAppPluginName
+    )
+    expect(inApp).toBeDefined()
+    expect(Gist.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: 'override-site-id' })
+    )
+  })
+})

--- a/packages/browser/src/browser/__tests__/in-app-plugin-integrations.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/in-app-plugin-integrations.integration.test.ts
@@ -45,10 +45,10 @@ describe('In-App Plugin integrations option', () => {
     )
   })
 
-  it('does not register the In-App Plugin when integrations sets it to false', async () => {
+  it('does not register the In-App Plugin when integrations sets enabled: false', async () => {
     const [analytics] = await AnalyticsBrowser.load(
       { writeKey: 'foo' },
-      { integrations: { [inAppPluginName]: false } }
+      { integrations: { [inAppPluginName]: { enabled: false } } }
     )
 
     const inApp = analytics.queue.plugins.find(
@@ -56,6 +56,19 @@ describe('In-App Plugin integrations option', () => {
     )
     expect(inApp).toBeUndefined()
     expect(Gist.setup).not.toHaveBeenCalled()
+  })
+
+  it('registers the In-App Plugin when integrations sets enabled: true', async () => {
+    const [analytics] = await AnalyticsBrowser.load(
+      { writeKey: 'foo' },
+      { integrations: { [inAppPluginName]: { enabled: true } } }
+    )
+
+    const inApp = analytics.queue.plugins.find(
+      (p) => p.name === inAppPluginName
+    )
+    expect(inApp).toBeDefined()
+    expect(Gist.setup).toHaveBeenCalled()
   })
 
   it('overrides CDN settings when integrations supplies an object', async () => {

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -210,20 +210,20 @@ async function registerPlugins(
   ).catch(() => [])
 
   const inAppPluginName = 'Customer.io In-App Plugin'
-  const inAppPluginOverride = options.integrations?.[inAppPluginName]
   const inAppPluginSettings: InAppPluginSettings | undefined =
-    inAppPluginOverride === false
-      ? undefined
-      : (mergedSettings[inAppPluginName] as InAppPluginSettings | undefined) ??
-        (inAppPluginOverride as InAppPluginSettings | undefined)
+    (mergedSettings[inAppPluginName] as InAppPluginSettings | undefined) ??
+    (options.integrations?.[inAppPluginName] as
+      | InAppPluginSettings
+      | undefined)
 
-  const inAppPlugin = inAppPluginSettings
-    ? await import(
-        /* webpackChunkName: "inAppPlugin" */ '../plugins/in-app-plugin'
-      ).then((mod) => {
-        return mod.InAppPlugin(inAppPluginSettings)
-      })
-    : undefined
+  const inAppPlugin =
+    inAppPluginSettings && inAppPluginSettings.enabled !== false
+      ? await import(
+          /* webpackChunkName: "inAppPlugin" */ '../plugins/in-app-plugin'
+        ).then((mod) => {
+          return mod.InAppPlugin(inAppPluginSettings)
+        })
+      : undefined
 
   const toRegister = [
     validation,

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -210,14 +210,12 @@ async function registerPlugins(
   ).catch(() => [])
 
   const inAppPluginName = 'Customer.io In-App Plugin'
-  let inAppPluginSettings = mergedSettings[
-    inAppPluginName
-  ] as InAppPluginSettings
-  if (!inAppPluginSettings) {
-    inAppPluginSettings = options.integrations?.[
-      inAppPluginName
-    ] as InAppPluginSettings
-  }
+  const inAppPluginOverride = options.integrations?.[inAppPluginName]
+  const inAppPluginSettings: InAppPluginSettings | undefined =
+    inAppPluginOverride === false
+      ? undefined
+      : (mergedSettings[inAppPluginName] as InAppPluginSettings | undefined) ??
+        (inAppPluginOverride as InAppPluginSettings | undefined)
 
   const inAppPlugin = inAppPluginSettings
     ? await import(

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -25,6 +25,7 @@ export type InAppPluginSettings = {
   _logging: GistConfig['logging'] | undefined
 
   anonymousInApp: boolean | false
+  enabled?: boolean
 }
 
 export function InAppPlugin(settings: InAppPluginSettings): Plugin {


### PR DESCRIPTION
`integrations: { "Customer.io In-App Plugin": { "enabled": false } }` will explicitly disable in-app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to optional plugin registration logic plus new integration tests; main risk is unintentionally changing when the In-App plugin loads for edge-case settings objects.
> 
> **Overview**
> Updates `AnalyticsBrowser` plugin registration so the `Customer.io In-App Plugin` is only loaded when settings exist **and** `enabled !== false`, allowing callers to explicitly disable the plugin even if it’s present in CDN settings.
> 
> Extends `InAppPluginSettings` with an optional `enabled` flag and adds an integration test suite covering default CDN loading, explicit enable/disable via `options.integrations`, and overriding CDN-provided plugin settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26303fb87f094bf391ebd1e4fcba7c8cbc05f510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->