### PR TITLE
chore: bump gist-web to 3.21.17

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.21.15",
+    "customerio-gist-web": "3.21.17",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.21.15
+    customerio-gist-web: 3.21.17
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5632,12 +5632,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.21.15":
-  version: 3.21.15
-  resolution: "customerio-gist-web@npm:3.21.15"
+"customerio-gist-web@npm:3.21.17":
+  version: 3.21.17
+  resolution: "customerio-gist-web@npm:3.21.17"
   dependencies:
     uuid: ^8.3.2
-  checksum: 0bed79b900ca97c5cebc1ed99cd5599d08c9ca9ddd91356116acd2ef3ff69a6352255f44a0e2b1312c898de6adbd7bd4afa1ca36137bdb11153ab14179bb4a6e
+  checksum: 47efd67f2ad325143e314d8d2ff0fc65f65a12eedfa9dcaa85575b20693be55551f3bac9fe34c81754c55809511f22d972d65f0bbd01c4fc1051c38119d46507
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.21.17](https://github.com/customerio/gist-web/releases/tag/3.21.17).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump; behavior changes are limited to whatever upstream `customerio-gist-web` changed and should be covered by integration tests.
> 
> **Overview**
> Updates the browser package’s `customerio-gist-web` dependency from `3.21.15` to `3.21.17`, along with the corresponding `yarn.lock` resolution/checksum changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf3f3bce1c2e57473c017fbc11b4c94135a4baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->