### PR TITLE
feat: support for Gist debug widget

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.21.13",
+    "customerio-gist-web": "3.21.18",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -294,6 +294,19 @@ async function loadAnalytics(
   // this is an ugly side-effect, but it's for the benefits of the plugins that get their cdn via getCDN()
   if (settings.cdnURL) setGlobalCDNUrl(settings.cdnURL)
 
+  // Eagerly load the in-app plugin chunk when a debug session is requested so
+  // the gist-web debug overlay initialises even if the CDP settings endpoint
+  // is unreachable (the chunk is otherwise only loaded after settings succeed).
+  if (
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('cio_debug_session') ===
+      'true'
+  ) {
+    import(
+      /* webpackChunkName: "inAppPlugin" */ '../plugins/in-app-plugin'
+    ).catch(() => {})
+  }
+
   const legacySettings =
     settings.cdnSettings ??
     (await loadLegacySettings(settings.writeKey, settings.cdnURL))

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -28,6 +28,7 @@ import { attachInspector } from '../core/inspector'
 import { Stats } from '../core/stats'
 import { InAppPluginSettings } from '../plugins/in-app-plugin'
 import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
+import { hasQueryString } from '../core/query-string'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -297,11 +298,7 @@ async function loadAnalytics(
   // Eagerly load the in-app plugin chunk when a debug session is requested so
   // the gist-web debug overlay initialises even if the CDP settings endpoint
   // is unreachable (the chunk is otherwise only loaded after settings succeed).
-  if (
-    typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).get('cio_debug_session') ===
-      'true'
-  ) {
+  if (hasQueryString('cio_debug_session', 'true')) {
     import(
       /* webpackChunkName: "inAppPlugin" */ '../plugins/in-app-plugin'
     ).catch(() => {})

--- a/packages/browser/src/core/query-string/index.ts
+++ b/packages/browser/src/core/query-string/index.ts
@@ -64,7 +64,7 @@ export function queryString(
 }
 
 export function hasQueryString(key: string, value?: string): boolean {
-  if (window == null) {
+  if (typeof window == 'undefined' || window?.location?.search == null) {
     return false;
   }
 

--- a/packages/browser/src/core/query-string/index.ts
+++ b/packages/browser/src/core/query-string/index.ts
@@ -62,3 +62,17 @@ export function queryString(
 
   return Promise.all(calls)
 }
+
+export function hasQueryString(key: string, value?: string): boolean {
+  if (window == null) {
+    return false;
+  }
+
+  const params = new URLSearchParams(window.location.search).get(key);
+  if (value === undefined) {
+    // no value provided, just check if the key exists
+    return params !== null;
+  }
+
+  return params === value;
+}

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -27,17 +27,19 @@ export type InAppPluginSettings = {
   anonymousInApp: boolean | false
 }
 
+if (
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('cio_debug_session') ===
+    'true'
+) {
+  Gist.setupDebugOverlay?.()
+}
+
 export function InAppPlugin(settings: InAppPluginSettings): Plugin {
   let _analytics: Analytics
   let _gistLoaded = false
   let _pluginLoaded = false
   const _eventTarget: EventTarget = new EventTarget()
-
-  // Run at plugin creation time (before load()) so the debug overlay appears
-  // even when the CDP endpoint is unreachable and load() never fires.
-  if (typeof window !== 'undefined') {
-    Gist.setupDebugOverlay?.()
-  }
 
   async function setAnonymousId() {
     const anonymousId = _analytics.user().anonymousId()

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -1,6 +1,7 @@
 import { Analytics } from '../../core/analytics'
 import { Context } from '../../core/context'
 import { Plugin } from '../../core/plugin'
+import { hasQueryString } from '../../core/query-string'
 
 import {
   InAppEvents,
@@ -27,11 +28,7 @@ export type InAppPluginSettings = {
   anonymousInApp: boolean | false
 }
 
-if (
-  typeof window !== 'undefined' &&
-  new URLSearchParams(window.location.search).get('cio_debug_session') ===
-    'true'
-) {
+if (hasQueryString('cio_debug_session', 'true')) {
   Gist.setupDebugOverlay?.()
 }
 

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -33,6 +33,12 @@ export function InAppPlugin(settings: InAppPluginSettings): Plugin {
   let _pluginLoaded = false
   const _eventTarget: EventTarget = new EventTarget()
 
+  // Run at plugin creation time (before load()) so the debug overlay appears
+  // even when the CDP endpoint is unreachable and load() never fires.
+  if (typeof window !== 'undefined') {
+    Gist.setupDebugOverlay?.()
+  }
+
   async function setAnonymousId() {
     const anonymousId = _analytics.user().anonymousId()
     if (anonymousId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.21.13
+    customerio-gist-web: 3.21.18
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5632,12 +5632,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.21.13":
-  version: 3.21.13
-  resolution: "customerio-gist-web@npm:3.21.13"
+"customerio-gist-web@npm:3.21.18":
+  version: 3.21.18
+  resolution: "customerio-gist-web@npm:3.21.18"
   dependencies:
     uuid: ^8.3.2
-  checksum: 70ca761f1b032fc3ec69faed6f39e8e990edb62e0bd6cf6260b2db0c7fddca85c0a94b9f166ba91cdf0c0111ebca84cc86487f3752ca4f8511f3f244d9f4a9de
+  checksum: e52a73c01674e21c2fa780b5859595626a5eab34adf5131f7846b0b8f08a3146c447367af6f8e581d42787c0dfe9426b5ec74376146067e73c56d8d1b02ed507
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior changes are gated behind a debug query parameter, with minimal impact to normal analytics initialization. Main risk is unintended side effects from the new eager chunk import or top-level overlay setup in edge environments (e.g., SSR).
> 
> **Overview**
> Adds a `hasQueryString` utility and uses it to detect `cio_debug_session=true`.
> 
> When set, `AnalyticsBrowser.load` now eagerly imports the `in-app-plugin` chunk (before remote settings load) and the In-App plugin triggers `Gist.setupDebugOverlay` on module load so the debug widget can initialize even if the settings endpoint is unreachable.
> 
> Bumps `customerio-gist-web` from `3.21.17` to `3.21.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2558b8ea204f351e8908f845ca24934456c8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->