### PR TITLE
manually update version

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customerio/cdp-analytics-browser",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/customerio/cdp-analytics-js",
@@ -48,7 +48,7 @@
     }
   ],
   "dependencies": {
-    "@customerio/cdp-analytics-core": "0.4.13",
+    "@customerio/cdp-analytics-core": "0.4.14",
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",

--- a/packages/browser/src/generated/version.ts
+++ b/packages/browser/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '0.4.13'
+export const version = '0.4.14'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customerio/cdp-analytics-core",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/customerio/cdp-analytics-js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customerio/cdp-analytics-node",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/customerio/cdp-analytics-js",
@@ -33,7 +33,7 @@
     "prepublish": "yarn run -T build"
   },
   "dependencies": {
-    "@customerio/cdp-analytics-core": "0.4.13",
+    "@customerio/cdp-analytics-core": "0.4.14",
     "@lukeed/uuid": "^2.0.0",
     "buffer": "^6.0.3",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,7 +755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@customerio/cdp-analytics-browser@workspace:packages/browser"
   dependencies:
-    "@customerio/cdp-analytics-core": 0.4.13
+    "@customerio/cdp-analytics-core": 0.4.14
     "@internal/config": 0.0.0
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics.js-integration": ^3.3.3
@@ -822,7 +822,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@customerio/cdp-analytics-node@workspace:packages/node"
   dependencies:
-    "@customerio/cdp-analytics-core": 0.4.13
+    "@customerio/cdp-analytics-core": 0.4.14
     "@internal/config": 0.0.0
     "@lukeed/uuid": ^2.0.0
     "@types/node": ^14


### PR DESCRIPTION
Manually update versions after failed workflow [run](https://github.com/customerio/cdp-analytics-js/actions/runs/25878555350).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump only (no runtime logic changes), updating package versions and internal `@customerio/cdp-analytics-core` dependency pins.
> 
> **Overview**
> Bumps `@customerio/cdp-analytics-browser`, `@customerio/cdp-analytics-core`, and `@customerio/cdp-analytics-node` from `0.4.13` to `0.4.14`.
> 
> Updates the browser generated `src/generated/version.ts` and aligns `yarn.lock` to the new `@customerio/cdp-analytics-core@0.4.14` dependency for browser and node packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfdb8722d567427952e0bf33dc8660a3ef1b3282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->