### PR TITLE
chore: bump gist-web to 3.21.19

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.21.18",
+    "customerio-gist-web": "3.21.19",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.21.18
+    customerio-gist-web: 3.21.19
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5632,12 +5632,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.21.18":
-  version: 3.21.18
-  resolution: "customerio-gist-web@npm:3.21.18"
+"customerio-gist-web@npm:3.21.19":
+  version: 3.21.19
+  resolution: "customerio-gist-web@npm:3.21.19"
   dependencies:
     uuid: ^8.3.2
-  checksum: e52a73c01674e21c2fa780b5859595626a5eab34adf5131f7846b0b8f08a3146c447367af6f8e581d42787c0dfe9426b5ec74376146067e73c56d8d1b02ed507
+  checksum: a65a8d34795725a5e0ca889346af04d60bc45d54b6ac5907d95a5885b20d0a5c878823b3fd3481980a50b077203fbcb66abaa6f6557ea9edab4ea0093c4e03d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.21.19](https://github.com/customerio/gist-web/releases/tag/3.21.19).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a dependency version bump with only `package.json`/`yarn.lock` changes; behavior changes are limited to whatever is introduced by `customerio-gist-web@3.21.19`.
> 
> **Overview**
> Updates the browser package’s `customerio-gist-web` dependency from `3.21.18` to `3.21.19` and refreshes `yarn.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3579239c0aa584b7c4c08a1a6baa9b5e98dc7106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->