### PR TITLE
feat: add inbox message events (opened, dismissed, action)

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.21.19",
+    "customerio-gist-web": "3.22.4",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
@@ -419,21 +419,6 @@ describe('Customer.io In-App Plugin', () => {
       )
     })
 
-    it('should not dispatch inbox events when events listener is not set', () => {
-      gistInboxMessageAction({
-        message: {
-          queueId: 'inbox-msg-1',
-          deliveryId: 'test-delivery',
-        },
-        action: 'opened',
-      })
-
-      expect(eventListener).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: InboxEvents.MessageOpened,
-        })
-      )
-    })
   })
 
   describe('Anonymous', () => {

--- a/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
@@ -1,13 +1,14 @@
 import { Analytics } from '../../../core/analytics'
 import { pageEnrichment } from '../../page-enrichment'
 import { CustomerioSettings } from '../../customerio'
-import { InAppPlugin, InAppPluginSettings } from '../'
+import { InAppPlugin, InAppPluginSettings, InboxEvents } from '../'
 import Gist from 'customerio-gist-web'
 
 describe('Customer.io In-App Plugin', () => {
   let analytics: Analytics
   let gistMessageShown: Function
   let gistMessageAction: Function
+  let gistInboxMessageAction: Function
   let gistEventDispatched: Function
 
   beforeEach(async () => {
@@ -30,6 +31,8 @@ describe('Customer.io In-App Plugin', () => {
           gistMessageShown = cb
         } else if (name === 'messageAction') {
           gistMessageAction = cb
+        } else if (name === 'inboxMessageAction') {
+          gistInboxMessageAction = cb
         } else if (name === 'eventDispatched') {
           gistEventDispatched = cb
         }
@@ -193,6 +196,244 @@ describe('Customer.io In-App Plugin', () => {
       },
       undefined
     )
+  })
+
+  describe('Inbox message actions', () => {
+    it('should trigger journey opened event for inbox message open', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'opened',
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'opened',
+      })
+    })
+
+    it('should trigger journey clicked event for inbox message click', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'openUrl',
+          name: 'button-name',
+          action: 'https://example.com',
+        },
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'clicked',
+        actionName: 'button-name',
+        actionValue: 'https://example.com',
+      })
+    })
+
+    it('should trigger journey clicked event for inbox dismiss click with name', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'dismiss',
+          name: 'close-button',
+        },
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'clicked',
+        actionName: 'close-button',
+        actionValue: undefined,
+      })
+    })
+
+    it('should trigger journey clicked event for inbox click without name', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'openUrl',
+          action: 'https://example.com',
+        },
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'clicked',
+        actionName: undefined,
+        actionValue: 'https://example.com',
+      })
+    })
+
+    it('should not trigger journey event for inbox dismiss without name', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'dismiss',
+        },
+      })
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('should trigger journey clicked event for inbox click without actionConfig', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'clicked',
+        actionName: undefined,
+        actionValue: undefined,
+      })
+    })
+
+    it('should not trigger journey event for inbox click without deliveryId', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: '',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'openUrl',
+          name: 'button-name',
+          action: 'https://example.com',
+        },
+      })
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('Inbox message events', () => {
+    let eventListener: jest.Mock
+    let gistInboxMessageActionWithEvents: Function
+
+    beforeEach(async () => {
+      eventListener = jest.fn()
+
+      const options: CustomerioSettings = { apiKey: 'foo' }
+      const eventsAnalytics = new Analytics({ writeKey: options.apiKey })
+
+      Gist.events = {
+        on: jest.fn((name: string, cb: Function) => {
+          if (name === 'inboxMessageAction') {
+            gistInboxMessageActionWithEvents = cb
+          }
+        }),
+        off: jest.fn(),
+        dispatch: jest.fn(),
+      } as unknown as typeof Gist.events
+
+      await eventsAnalytics.register(
+        InAppPlugin({
+          siteId: 'siteid',
+          events: eventListener,
+        } as InAppPluginSettings),
+        pageEnrichment
+      )
+    })
+
+    it('should dispatch in-app-inbox:message-opened on inbox message open', () => {
+      gistInboxMessageActionWithEvents({
+        message: {
+          queueId: 'inbox-msg-1',
+          deliveryId: 'test-delivery',
+        },
+        action: 'opened',
+      })
+
+      expect(eventListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: InboxEvents.MessageOpened,
+          detail: {
+            messageId: 'inbox-msg-1',
+            deliveryId: 'test-delivery',
+          },
+        })
+      )
+    })
+
+    it('should dispatch in-app-inbox:message-dismissed on inbox message dismissed', () => {
+      gistInboxMessageActionWithEvents({
+        message: {
+          queueId: 'inbox-msg-1',
+          deliveryId: 'test-delivery',
+        },
+        action: 'dismissed',
+      })
+
+      expect(eventListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: InboxEvents.MessageDismissed,
+          detail: {
+            messageId: 'inbox-msg-1',
+            deliveryId: 'test-delivery',
+          },
+        })
+      )
+    })
+
+    it('should dispatch in-app-inbox:message-action on inbox click', () => {
+      gistInboxMessageActionWithEvents({
+        message: {
+          queueId: 'inbox-msg-1',
+          deliveryId: 'test-delivery',
+        },
+        action: 'clicked',
+        actionConfig: {
+          behavior: 'openUrl',
+          name: 'button-name',
+          action: 'https://example.com',
+        },
+      })
+
+      expect(eventListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: InboxEvents.MessageAction,
+          detail: {
+            messageId: 'inbox-msg-1',
+            deliveryId: 'test-delivery',
+            action: 'https://example.com',
+            name: 'button-name',
+            actionName: 'button-name',
+            actionValue: 'https://example.com',
+          },
+        })
+      )
+    })
+
+    it('should not dispatch inbox events when events listener is not set', () => {
+      gistInboxMessageAction({
+        message: {
+          queueId: 'inbox-msg-1',
+          deliveryId: 'test-delivery',
+        },
+        action: 'opened',
+      })
+
+      expect(eventListener).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: InboxEvents.MessageOpened,
+        })
+      )
+    })
   })
 
   describe('Anonymous', () => {

--- a/packages/browser/src/plugins/in-app-plugin/events.ts
+++ b/packages/browser/src/plugins/in-app-plugin/events.ts
@@ -5,7 +5,13 @@ export enum InAppEvents {
     MessageAction = 'in-app:message-action',
 }
 
-export const allEvents:string[] = Object.values(InAppEvents);
+export enum InboxEvents {
+    MessageOpened = 'in-app-inbox:message-opened',
+    MessageDismissed = 'in-app-inbox:message-dismissed',
+    MessageAction = 'in-app-inbox:message-action',
+}
+
+export const allEvents:string[] = [...Object.values(InAppEvents), ...Object.values(InboxEvents)];
 
 export enum JourneysEvents {
     Metric = 'Report Delivery Event',

--- a/packages/browser/src/plugins/in-app-plugin/inbox_messages.ts
+++ b/packages/browser/src/plugins/in-app-plugin/inbox_messages.ts
@@ -17,6 +17,22 @@ export interface GistInboxMessage {
   opened: boolean
 }
 
+export type InboxActionBehavior = 'openUrl' | 'dismiss' | 'openDeeplink' | 'performAction'
+
+export interface InboxActionConfig {
+  behavior: InboxActionBehavior
+  action?: string
+  name?: string
+  dismiss?: boolean
+  newTab?: boolean
+}
+
+export interface InboxMessageActionParams {
+  message: GistInboxMessage
+  action: 'opened' | 'dismissed' | 'clicked' | 'unopened'
+  actionConfig?: InboxActionConfig
+}
+
 export interface InboxMessage {
   // Unique identifier for this messeage
   readonly messageId: string

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -5,6 +5,7 @@ import { hasQueryString } from '../../core/query-string'
 
 import {
   InAppEvents,
+  InboxEvents,
   JourneysEvents,
   newEvent,
   allEvents,
@@ -12,10 +13,10 @@ import {
   ContentType,
 } from './events'
 import Gist, { type GistConfig } from 'customerio-gist-web'
-import type { InboxAPI, InboxMessage, GistInboxMessage } from './inbox_messages'
+import type { InboxAPI, InboxMessage, GistInboxMessage, InboxActionConfig, InboxMessageActionParams } from './inbox_messages'
 import { createInboxAPI } from './inbox_messages'
 
-export { InAppEvents }
+export { InAppEvents, InboxEvents }
 export type { InboxAPI, InboxMessage }
 
 export type InAppPluginSettings = {
@@ -108,9 +109,45 @@ export function InAppPlugin(settings: InAppPluginSettings): Plugin {
       }
     })
 
-    Gist.events.on('inboxMessageAction', (params: any) => {
-      if (params?.message && params?.action !== '') {
-        _handleInboxMessageAction(_analytics, params.message, params.action)
+    Gist.events.on('inboxMessageAction', (event: unknown) => {
+      const params = event as InboxMessageActionParams
+      if (params?.message && params?.action) {
+        if (settings.events) {
+          const { message, action, actionConfig } = params
+          if (action === 'opened') {
+            _eventTarget.dispatchEvent(
+              newEvent(InboxEvents.MessageOpened, {
+                messageId: message.queueId,
+                deliveryId: message.deliveryId,
+              })
+            )
+          } else if (action === 'dismissed') {
+            _eventTarget.dispatchEvent(
+              newEvent(InboxEvents.MessageDismissed, {
+                messageId: message.queueId,
+                deliveryId: message.deliveryId,
+              })
+            )
+          } else if (action === 'clicked') {
+            _eventTarget.dispatchEvent(
+              newEvent(InboxEvents.MessageAction, {
+                messageId: message.queueId,
+                deliveryId: message.deliveryId,
+                action: actionConfig?.action,
+                name: actionConfig?.name,
+                actionName: actionConfig?.name,
+                actionValue: actionConfig?.action,
+              })
+            )
+          }
+        }
+
+        _handleInboxMessageAction(
+          _analytics,
+          params.message,
+          params.action,
+          params.actionConfig
+        )
       }
     })
 
@@ -268,17 +305,31 @@ export function InAppPlugin(settings: InAppPluginSettings): Plugin {
 function _handleInboxMessageAction(
   analyticsInstance: Analytics,
   message: GistInboxMessage,
-  action: string
+  action: InboxMessageActionParams['action'],
+  actionConfig?: InboxActionConfig
 ) {
   const deliveryId = message?.deliveryId
-  if (
-    action === 'opened' &&
-    typeof deliveryId !== 'undefined' &&
-    deliveryId !== ''
-  ) {
+  if (typeof deliveryId === 'undefined' || deliveryId === '') {
+    return
+  }
+
+  if (action === 'opened') {
     void analyticsInstance.track(JourneysEvents.Metric, {
-      deliveryId: message.deliveryId,
+      deliveryId: deliveryId,
       metric: JourneysEvents.Opened,
+    })
+    return
+  }
+
+  if (action === 'clicked') {
+    if (actionConfig?.behavior === 'dismiss' && !actionConfig?.name) {
+      return
+    }
+    void analyticsInstance.track(JourneysEvents.Metric, {
+      deliveryId: deliveryId,
+      metric: JourneysEvents.Clicked,
+      actionName: actionConfig?.name,
+      actionValue: actionConfig?.action,
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.21.19
+    customerio-gist-web: 3.22.4
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -833,6 +833,13 @@ __metadata:
     uuid: ^9.0.0
   languageName: unknown
   linkType: soft
+
+"@customerio/jist@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "@customerio/jist@npm:0.1.6"
+  checksum: 986a2603c1a5784552a99d18d6be23966a65176a0006bf8ab6f759f03d338bd20bbcbf262c4e54b5e15cb101ddcab531239f432a1802b5b5c215ba3af9ec45e9
+  languageName: node
+  linkType: hard
 
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.2
@@ -5632,12 +5639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.21.19":
-  version: 3.21.19
-  resolution: "customerio-gist-web@npm:3.21.19"
+"customerio-gist-web@npm:3.22.4":
+  version: 3.22.4
+  resolution: "customerio-gist-web@npm:3.22.4"
   dependencies:
-    uuid: ^8.3.2
-  checksum: a65a8d34795725a5e0ca889346af04d60bc45d54b6ac5907d95a5885b20d0a5c878823b3fd3481980a50b077203fbcb66abaa6f6557ea9edab4ea0093c4e03d5
+    "@customerio/jist": ^0.1.6
+    uuid: ^14.0.0
+  checksum: b6140591f07930656c58d518d8ddcd3a51438aeba0fe43329a246bf45cecc5dd16dc11239f06fb822d5a930e3884135438734582f58b35d14430feda3d2d7be3
   languageName: node
   linkType: hard
 
@@ -12708,6 +12716,15 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 8793629d2799f500aeea9fcd0aec6c4e9fbcc4d62ed42159ad96be345c3fffac1bbf61a23e18e2782600884fee05e6d4012ce4b70d0037c8e987533ae6a77870
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 08608584a79e987cdae000fa8eb724fa51dd8aafc136cd9fa9a8c87d07b246c56eec5fd9027fdb3e49a863eedf758bc19e325909ce281955c7a027fed67dc89e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add `in-app-inbox:message-opened`, `in-app-inbox:message-dismissed`, and `in-app-inbox:message-action` events, mirroring the existing in-app message events
- Bump `customerio-gist-web` to 3.22.4 which adds `dismissed` action dispatch and `actionConfig` on clicked events
- Add typed `InboxActionConfig` and `InboxMessageActionParams` interfaces for the inbox message action handler
- Fix inbox click tracking: clicks now always track (matching in-app behavior) even when `actionConfig` is absent

## Test plan
- [x] Existing in-app plugin tests pass (no regressions)
- [x] New tests for inbox event dispatching (opened, dismissed, action)
- [x] New tests for inbox journey tracking (opened, clicked with/without actionConfig, dismiss suppression)

Addresses: [INAPP-14477](https://linear.app/customerio/issue/INAPP-14477/update-cdp-analytics-js-to-support-new-inbox-click-events)

Part of: [INAPP-14376](https://linear.app/customerio/issue/INAPP-14376/build-a-configurable-notification-inbox-within-the-web-sdk)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery-metric tracking and public inbox event surface in the browser SDK; behavior shifts for inbox clicks without actionConfig and dismiss handling, though scope is limited to the in-app plugin and is well covered by tests.
> 
> **Overview**
> Extends the browser **In-App plugin** for **inbox** interactions by bumping **`customerio-gist-web`** to **3.22.4** and wiring new Gist `inboxMessageAction` payloads (including **`dismissed`** and **`actionConfig`** on clicks).
> 
> When **`settings.events`** is set, the plugin now dispatches **`InboxEvents`** custom events (`in-app-inbox:message-opened`, `message-dismissed`, `message-action`) parallel to existing in-app events, and registers them in **`allEvents`**. **`_handleInboxMessageAction`** is refactored with typed **`InboxMessageActionParams`** / **`InboxActionConfig`**: it still reports **opened** and **clicked** via **`Report Delivery Event`**, but **click** tracking now runs even without **`actionConfig`**, while **dismiss** clicks without a **name** are suppressed. Tests cover journey metrics and event dispatch for inbox open, dismiss, and click variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e217d7e9eba30f051b25e4716d7e5c0c2d4a8f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->