### PR TITLE
feat: expose colorScheme option for in-app messages

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.22.4",
+    "customerio-gist-web": "3.23.0",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -12,12 +12,12 @@ import {
   gistToCIO,
   ContentType,
 } from './events'
-import Gist, { type GistConfig } from 'customerio-gist-web'
+import Gist, { type GistConfig, type ColorScheme } from 'customerio-gist-web'
 import type { InboxAPI, InboxMessage, GistInboxMessage, InboxActionConfig, InboxMessageActionParams } from './inbox_messages'
 import { createInboxAPI } from './inbox_messages'
 
 export { InAppEvents, InboxEvents }
-export type { InboxAPI, InboxMessage }
+export type { InboxAPI, InboxMessage, ColorScheme }
 
 export type InAppPluginSettings = {
   siteId: string | undefined
@@ -28,6 +28,15 @@ export type InAppPluginSettings = {
 
   anonymousInApp: boolean | false
   enabled?: boolean
+  /**
+   * Controls the color scheme for in-app messages.
+   * - `'default'` — always use light mode
+   * - `'system'` — follow the user's OS-level color scheme preference
+   * - `'auto'` — detect the color scheme from the page and react to live changes
+   *
+   * Defaults to `'default'` (light) when not specified.
+   */
+  colorScheme?: GistConfig['colorScheme']
 }
 
 if (hasQueryString('cio_debug_session', 'true')) {
@@ -267,6 +276,7 @@ export function InAppPlugin(settings: InAppPluginSettings): Plugin {
         env: settings._env ? settings._env : 'prod',
         logging: settings._logging,
         useAnonymousSession: settings.anonymousInApp,
+        colorScheme: settings.colorScheme,
       })
       _gistLoaded = true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.22.4
+    customerio-gist-web: 3.23.0
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5639,13 +5639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.22.4":
-  version: 3.22.4
-  resolution: "customerio-gist-web@npm:3.22.4"
+"customerio-gist-web@npm:3.23.0":
+  version: 3.23.0
+  resolution: "customerio-gist-web@npm:3.23.0"
   dependencies:
     "@customerio/jist": ^0.1.6
     uuid: ^14.0.0
-  checksum: b6140591f07930656c58d518d8ddcd3a51438aeba0fe43329a246bf45cecc5dd16dc11239f06fb822d5a930e3884135438734582f58b35d14430feda3d2d7be3
+  checksum: c99cd1fc2a2dc95bed7c1a64c623eec8c47716a2c9b5677d4997c72495609399e07001c9607e4de356a393db6c64dbe354649443d52154c6d915999b036bddc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `customerio-gist-web` from 3.22.4 to 3.23.0, which adds `colorScheme` support
- Exposes the new `colorScheme` option on `InAppPluginSettings` so SDK consumers can control in-app message theming
- Re-exports the `ColorScheme` type for consumer convenience
- Options: `'default'` (light, the default), `'system'` (OS preference), `'auto'` (detect from page + react to live changes)

## Test plan
- [x] Verify in-app messages render correctly with each colorScheme value (`default`, `system`, `auto`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency bump plus an optional config passthrough to Gist; no auth, data, or core analytics logic changes.
> 
> **Overview**
> Upgrades **`customerio-gist-web`** to **3.23.0** and wires through a new **`colorScheme`** setting on **`InAppPlugin`**, so integrators can theme in-app messages via **`'default'`**, **`'system'`**, or **`'auto'`** (documented on **`InAppPluginSettings`**). The value is passed into **`Gist.setup`** on load, and **`ColorScheme`** is re-exported for TypeScript consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace5e9e0d34c5a4cc809b55f655f2bab687cf314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->