### PR TITLE
chore: bump gist-web to 3.23.1

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.23.0",
+    "customerio-gist-web": "3.23.1",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.23.0
+    customerio-gist-web: 3.23.1
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5639,13 +5639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.23.0":
-  version: 3.23.0
-  resolution: "customerio-gist-web@npm:3.23.0"
+"customerio-gist-web@npm:3.23.1":
+  version: 3.23.1
+  resolution: "customerio-gist-web@npm:3.23.1"
   dependencies:
     "@customerio/jist": ^0.1.6
     uuid: ^14.0.0
-  checksum: c99cd1fc2a2dc95bed7c1a64c623eec8c47716a2c9b5677d4997c72495609399e07001c9607e4de356a393db6c64dbe354649443d52154c6d915999b036bddc9
+  checksum: 1b90d342bafb4d78a752670559b957a8b95909483d7c4fd33eaacde56e77c7ca6fa40b90d3a8ba3ee1f024a6692809c50f5b0599b7f3cdb266c03bcfef2644a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.23.1](https://github.com/customerio/gist-web/releases/tag/3.23.1).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bump with no application code changes; behavior follows whatever shipped in gist-web 3.23.1.
> 
> **Overview**
> Bumps the **`customerio-gist-web`** dependency from **3.23.0** to **3.23.1** in `@customerio/cdp-analytics-browser` and refreshes **`yarn.lock`** so the monorepo resolves the new package version and checksum.
> 
> This is an automated version bump tied to the [gist-web 3.23.1](https://github.com/customerio/gist-web/releases/tag/3.23.1) release; browser in-app messaging still comes through the existing in-app plugin integration with no local source changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fe47e82f6df337004be6f543568b772b81b0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->