### PR TITLE
chore: bump gist-web to 3.23.2

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.23.1",
+    "customerio-gist-web": "3.23.2",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.23.1
+    customerio-gist-web: 3.23.2
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5639,13 +5639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.23.1":
-  version: 3.23.1
-  resolution: "customerio-gist-web@npm:3.23.1"
+"customerio-gist-web@npm:3.23.2":
+  version: 3.23.2
+  resolution: "customerio-gist-web@npm:3.23.2"
   dependencies:
     "@customerio/jist": ^0.1.6
     uuid: ^14.0.0
-  checksum: 1b90d342bafb4d78a752670559b957a8b95909483d7c4fd33eaacde56e77c7ca6fa40b90d3a8ba3ee1f024a6692809c50f5b0599b7f3cdb266c03bcfef2644a7
+  checksum: 8b39df99117d6918da0a8c417a256d0148bde89d30c484d432dc2c7e4c9b2985780977f73c92dba45ee646c264513214bd201aa544f9409dc6243623468ab8e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.23.2](https://github.com/customerio/gist-web/releases/tag/3.23.2).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no code changes; behavior depends on gist-web 3.23.2 release notes but scope is limited to the in-app SDK integration.
> 
> **Overview**
> Bumps the **`customerio-gist-web`** dependency from **3.23.1** to **3.23.2** in `@customerio/cdp-analytics-browser` and refreshes **`yarn.lock`** (resolution, version, checksum). No application source changes—only the packaged Gist in-app SDK version used by the in-app plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9ead316efb430072322f96edb8c7050da57c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->