### PR TITLE
chore: bump gist-web to 3.23.3

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.23.2",
+    "customerio-gist-web": "3.23.3",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.23.2
+    customerio-gist-web: 3.23.3
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5639,13 +5639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.23.2":
-  version: 3.23.2
-  resolution: "customerio-gist-web@npm:3.23.2"
+"customerio-gist-web@npm:3.23.3":
+  version: 3.23.3
+  resolution: "customerio-gist-web@npm:3.23.3"
   dependencies:
     "@customerio/jist": ^0.1.6
     uuid: ^14.0.0
-  checksum: 8b39df99117d6918da0a8c417a256d0148bde89d30c484d432dc2c7e4c9b2985780977f73c92dba45ee646c264513214bd201aa544f9409dc6243623468ab8e1
+  checksum: 9decaa677c86351a9ee7b723229e890cce6363d23d614e90a7e6eab943dd593db8c37e423470f2b5da05f17101ee8e4f512f23001cfed27fdfd9aee38e5f0701
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.23.3](https://github.com/customerio/gist-web/releases/tag/3.23.3).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level third-party dependency update with no local code changes; behavior follows gist-web 3.23.3 release notes.
> 
> **Overview**
> Bumps the **`customerio-gist-web`** dependency from **3.23.2** to **3.23.3** in `@customerio/cdp-analytics-browser` and refreshes **`yarn.lock`**. There are no application source changes in this PR—only the pinned version used by the in-app plugin integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e16088dde4b9e396f64f3f5900bde5bbec89f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->