### PR TITLE
INAPP-14507: track inbox sent + enrich inbox metrics with message_id/inbox_id

### DIFF
--- a/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/in-app-plugin/__tests__/index.test.ts
@@ -9,6 +9,7 @@ describe('Customer.io In-App Plugin', () => {
   let gistMessageShown: Function
   let gistMessageAction: Function
   let gistInboxMessageAction: Function
+  let gistInboxMessageReceived: Function
   let gistEventDispatched: Function
 
   beforeEach(async () => {
@@ -33,6 +34,8 @@ describe('Customer.io In-App Plugin', () => {
           gistMessageAction = cb
         } else if (name === 'inboxMessageAction') {
           gistInboxMessageAction = cb
+        } else if (name === 'inboxMessageReceived') {
+          gistInboxMessageReceived = cb
         } else if (name === 'eventDispatched') {
           gistEventDispatched = cb
         }
@@ -318,6 +321,42 @@ describe('Customer.io In-App Plugin', () => {
         },
       })
       expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('should trigger journey sent event when an inbox message is received', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageReceived({
+        message: {
+          deliveryId: 'test-delivery',
+          queueId: 'queue-1',
+          topics: ['cio_inbox_default'],
+        },
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'sent',
+        message_id: 'queue-1',
+        inbox_id: 'default',
+      })
+    })
+
+    it('should include message_id and inbox_id derived from the topic', async () => {
+      const spy = jest.spyOn(analytics, 'track')
+      gistInboxMessageAction({
+        message: {
+          deliveryId: 'test-delivery',
+          messageId: 'msg-1',
+          queueId: 'queue-1',
+          topics: ['cio_inbox_news'],
+        },
+        action: 'opened',
+      })
+      expect(spy).toBeCalledWith('Report Delivery Event', {
+        deliveryId: 'test-delivery',
+        metric: 'opened',
+        message_id: 'msg-1',
+        inbox_id: 'news',
+      })
     })
   })
 

--- a/packages/browser/src/plugins/in-app-plugin/events.ts
+++ b/packages/browser/src/plugins/in-app-plugin/events.ts
@@ -18,6 +18,7 @@ export enum JourneysEvents {
     Content = 'Report Content Event',
     Opened = 'opened',
     Clicked = 'clicked',
+    Sent = 'sent',
     ViewedContent = 'viewed_content',
     ClickedContent = 'clicked_content'
 }

--- a/packages/browser/src/plugins/in-app-plugin/inbox_messages.ts
+++ b/packages/browser/src/plugins/in-app-plugin/inbox_messages.ts
@@ -3,6 +3,36 @@ import { JourneysEvents } from './events'
 
 const CIO_TOPIC_PREFIX = '_cio'
 
+// Inbox topics are stored as `cio_inbox_<inbox_id>`, so the inbox id is derived
+// from the message's topic rather than carried as a separate field.
+const INBOX_TOPIC_PREFIX = 'cio_inbox_'
+
+export function deriveInboxId(topics?: string[]): string | undefined {
+  const topic = topics?.find((t) => t.startsWith(INBOX_TOPIC_PREFIX))
+  return topic ? topic.slice(INBOX_TOPIC_PREFIX.length) : undefined
+}
+
+// Single definition of an inbox delivery-metric payload, shared by the gist
+// event handlers and the headless inbox API's trackClick. Inbox-specific (adds
+// message_id/inbox_id) — distinct from the in-app delivery metrics in index.ts.
+export function trackInboxMetric(
+  analyticsInstance: Analytics,
+  message: GistInboxMessage,
+  metric: JourneysEvents,
+  extra?: Record<string, unknown>
+): void {
+  if (!message?.deliveryId) {
+    return
+  }
+  void analyticsInstance.track(JourneysEvents.Metric, {
+    deliveryId: message.deliveryId,
+    metric,
+    message_id: message.messageId ?? message.queueId,
+    inbox_id: deriveInboxId(message.topics),
+    ...extra,
+  })
+}
+
 export interface GistInboxMessage {
   messageType: string
   expiry: string
@@ -10,6 +40,7 @@ export interface GistInboxMessage {
   topics?: string[]
   type: string
   properties: { [key: string]: any }
+  messageId?: string
   queueId: string
   userToken: string
   deliveryId: string
@@ -121,12 +152,7 @@ function createInboxMessage(
     type: gistMessage.type || '',
     topics: gistMessage.topics || [],
     trackClick: (trackedResponse?: string) => {
-      if(typeof gistMessage.deliveryId === 'undefined' || gistMessage.deliveryId === '') {
-        return
-      }
-      void analyticsInstance.track(JourneysEvents.Metric, {
-        deliveryId: gistMessage.deliveryId,
-        metric: JourneysEvents.Clicked,
+      trackInboxMetric(analyticsInstance, gistMessage, JourneysEvents.Clicked, {
         actionName: trackedResponse,
       })
     },

--- a/packages/browser/src/plugins/in-app-plugin/index.ts
+++ b/packages/browser/src/plugins/in-app-plugin/index.ts
@@ -14,7 +14,7 @@ import {
 } from './events'
 import Gist, { type GistConfig, type ColorScheme } from 'customerio-gist-web'
 import type { InboxAPI, InboxMessage, GistInboxMessage, InboxActionConfig, InboxMessageActionParams } from './inbox_messages'
-import { createInboxAPI } from './inbox_messages'
+import { createInboxAPI, trackInboxMetric } from './inbox_messages'
 
 export { InAppEvents, InboxEvents }
 export type { InboxAPI, InboxMessage, ColorScheme }
@@ -157,6 +157,13 @@ export function InAppPlugin(settings: InAppPluginSettings): Plugin {
           params.action,
           params.actionConfig
         )
+      }
+    })
+
+    Gist.events.on('inboxMessageReceived', (event: unknown) => {
+      const params = event as { message?: GistInboxMessage }
+      if (params?.message) {
+        trackInboxMetric(_analytics, params.message, JourneysEvents.Sent)
       }
     })
 
@@ -318,16 +325,8 @@ function _handleInboxMessageAction(
   action: InboxMessageActionParams['action'],
   actionConfig?: InboxActionConfig
 ) {
-  const deliveryId = message?.deliveryId
-  if (typeof deliveryId === 'undefined' || deliveryId === '') {
-    return
-  }
-
   if (action === 'opened') {
-    void analyticsInstance.track(JourneysEvents.Metric, {
-      deliveryId: deliveryId,
-      metric: JourneysEvents.Opened,
-    })
+    trackInboxMetric(analyticsInstance, message, JourneysEvents.Opened)
     return
   }
 
@@ -335,9 +334,7 @@ function _handleInboxMessageAction(
     if (actionConfig?.behavior === 'dismiss' && !actionConfig?.name) {
       return
     }
-    void analyticsInstance.track(JourneysEvents.Metric, {
-      deliveryId: deliveryId,
-      metric: JourneysEvents.Clicked,
+    trackInboxMetric(analyticsInstance, message, JourneysEvents.Clicked, {
       actionName: actionConfig?.name,
       actionValue: actionConfig?.action,
     })


### PR DESCRIPTION
## What

Extends the inbox metric tracking added in #110:
- New **`sent`** metric — emitted when an inbox message lands in the end-user's inbox (listens for the `inboxMessageReceived` gist event).
- Enriches inbox delivery metrics (`opened`/`clicked`/`sent`) with **`message_id`** and **`inbox_id`** (derived from the `cio_inbox_<id>` topic).
- Consolidates the inbox metric payload into one `trackInboxMetric` helper, reused by the gist event handlers and the headless `trackClick`.

## Why

Powers per-end-user Notification Inbox success metrics in Mixpanel (INAPP-14507): activation (opens/clicks) and retention (repeat sends to the same inbox, keyed on `inbox_id`). Mirrors how in-app delivery metrics already flow to Mixpanel.

## Notes

- Matches #110's behavior: `dismissed` is forwarded to consumer `settings.events` only, not tracked as a Mixpanel metric (in-app parity); the dismiss-on-click guard is unchanged.
- Paired with gist-web producer-side PR: customerio/gist-web#163.
- `inbox_id` is derived client-side from the topic to avoid plumbing a new field through gist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to inbox analytics event shape and a new gist listener; no auth or data-persistence changes, with behavior covered by new unit tests.
> 
> **Overview**
> Extends Notification Inbox analytics by emitting a **`sent`** delivery metric when Gist fires `inboxMessageReceived`, and by enriching inbox **`opened`**, **`clicked`**, and **`sent`** `Report Delivery Event` payloads with **`message_id`** and **`inbox_id`**.
> 
> **`inbox_id`** is parsed client-side from the `cio_inbox_<id>` topic via **`deriveInboxId`**; **`message_id`** uses `messageId` when present, otherwise **`queueId`**. Inbox metric tracking is centralized in **`trackInboxMetric`**, shared by the gist handlers, **`_handleInboxMessageAction`**, and headless **`trackClick`**. Existing dismiss-without-name and empty **`deliveryId`** guards stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 639500b672b21274e3178fc8a00038b6866698c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->