### PR TITLE
chore: bump gist-web to 3.23.6

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "customerio-gist-web": "3.23.3",
+    "customerio-gist-web": "3.23.6",
     "dset": "^3.1.2",
     "js-cookie": "^3.0.6",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
     aws-sdk: ^2.814.0
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.23.3
+    customerio-gist-web: 3.23.6
     dset: ^3.1.2
     execa: ^4.1.0
     flat: ^5.0.2
@@ -834,10 +834,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@customerio/jist@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "@customerio/jist@npm:0.1.6"
-  checksum: 986a2603c1a5784552a99d18d6be23966a65176a0006bf8ab6f759f03d338bd20bbcbf262c4e54b5e15cb101ddcab531239f432a1802b5b5c215ba3af9ec45e9
+"@customerio/jist@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@customerio/jist@npm:0.3.0"
+  checksum: a5c05fa547431e897da9f53cbaf80b62b2eb7311fe1775bac4e292b7b77dcccb152d00fd804237a5ee4af931537d8a0ebfcabdfb16dc296f90734f64d0f7e3e5
   languageName: node
   linkType: hard
 
@@ -5661,13 +5661,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.23.3":
-  version: 3.23.3
-  resolution: "customerio-gist-web@npm:3.23.3"
+"customerio-gist-web@npm:3.23.6":
+  version: 3.23.6
+  resolution: "customerio-gist-web@npm:3.23.6"
   dependencies:
-    "@customerio/jist": ^0.1.6
+    "@customerio/jist": ^0.3.0
     uuid: ^14.0.0
-  checksum: 9decaa677c86351a9ee7b723229e890cce6363d23d614e90a7e6eab943dd593db8c37e423470f2b5da05f17101ee8e4f512f23001cfed27fdfd9aee38e5f0701
+  checksum: 475b99debd7f5f5de10072e9813765d8d2d9982fde9e03ac514e7246602a0bb8d9477f8fa8fc19a5331d2bdb9f1f5e2902938e11214d123b5c2c09ff9e2fa648
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.23.6](https://github.com/customerio/gist-web/releases/tag/3.23.6).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local code edits; risk is limited to whatever changed inside gist-web/jist between versions.
> 
> **Overview**
> Bumps the browser package’s **`customerio-gist-web`** dependency from **3.23.3** to **3.23.6** and refreshes **`yarn.lock`**. The lockfile also picks up **`@customerio/jist`** **0.1.6 → 0.3.0** as a transitive dependency of gist-web.
> 
> There are **no source changes** in this repo—only the version pins. In-app/Gist behavior comes from the upgraded gist-web release ([3.23.6](https://github.com/customerio/gist-web/releases/tag/3.23.6)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0150ac2dd415dacf5f3785d64077814298804d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->