### PR TITLE
ci: pin npm to v11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           scope: '@customerio'
 
       - name: Install npm 11.5.1+ for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install
         run: |
@@ -109,7 +109,7 @@ jobs:
           scope: '@customerio'
 
       - name: Install npm 11.5.1+ for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install
         run: |


### PR DESCRIPTION
## What changed

Pin the npm version installed in both release publish jobs to `npm@11` instead of `npm@latest`.

## Why

Release run [29427759943](https://github.com/customerio/cdp-analytics-js/actions/runs/29427759943) failed in both the `npm` and `github` jobs with `EBADENGINE`: `npm@latest` now resolves to npm 12.0.1, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, while the jobs run on Node 20 (runner had v20.20.2).

The step exists to get npm ≥ 11.5.1 for OIDC trusted publishing. npm 11.x satisfies that and supports Node 20 (engines `^20.17.0 || >=22.9.0`). Pinning the major instead of chasing `latest` also prevents the next npm major from breaking releases the same way.

## Testing

- Verified against the npm registry: `npm@11` resolves to 11.18.0 (engines `^20.17.0 || >=22.9.0`, compatible with the runner's Node 20.20.2, and ≥ 11.5.1 so OIDC publishing is supported); `npm@latest` is 12.0.1 (requires Node ≥ 22.22.2 — the exact failure in the run above).
- Workflow-YAML-only change; suggest a dry-run release after merge to confirm end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application runtime impact; it reduces release breakage risk from unpinned npm majors.
> 
> **Overview**
> Pins global npm in the **`npm`** and **`github`** release jobs from `npm@latest` to **`npm@11`**, so installs stay on a major that supports **Node 20** and still meets the **≥ 11.5.1** requirement for OIDC trusted publishing.
> 
> This avoids release failures when `npm@latest` moves to npm 12, which enforces newer Node engines than the workflow’s `node-version: 20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c77819b20d727ad6a4baf0c8c902c2df9e727ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->