### PR TITLE
chore: bump gist-web to 3.25.0

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.10",
-    "customerio-gist-web": "3.24.0",
+    "customerio-gist-web": "3.25.0",
     "dset": "^3.1.4",
     "js-cookie": "^3.0.7",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,7 +781,7 @@ __metadata:
     "@types/spark-md5": ^3.0.2
     circular-dependency-plugin: ^5.2.2
     compression-webpack-plugin: ^8.0.1
-    customerio-gist-web: 3.24.0
+    customerio-gist-web: 3.25.0
     dset: ^3.1.4
     execa: ^4.1.0
     flat: ^5.0.2
@@ -5457,13 +5457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"customerio-gist-web@npm:3.24.0":
-  version: 3.24.0
-  resolution: "customerio-gist-web@npm:3.24.0"
+"customerio-gist-web@npm:3.25.0":
+  version: 3.25.0
+  resolution: "customerio-gist-web@npm:3.25.0"
   dependencies:
     "@customerio/jist": ^0.3.0
     uuid: ^14.0.0
-  checksum: 79a4cadf50ea2c8137f654dd6dd4b711a2ff218ba84dd692190a6dea0735f1ab6ef338923291490d33d7d807449055af35907b17c16265921e4362b79140499f
+  checksum: 74041fb09b19385be838e9d81e9eeef5b8b6dcbef40243dcbf15918c2484fa9fff9e35aad2202a72b7b4e0b0fab0ba737454718ba6d5379dfc6219b3f0d638e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated version bump triggered by [gist-web 3.25.0](https://github.com/customerio/gist-web/releases/tag/3.25.0).

---
*Created by [gist-web-deploy](https://github.com/customerio/gist-web-deploy)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local code changes; any functional impact depends on upstream gist-web 3.25.0 release notes.
> 
> **Overview**
> Bumps the **`customerio-gist-web`** dependency from **3.24.0** to **3.25.0** in `@customerio/cdp-analytics-browser` and refreshes **`yarn.lock`** (including the package checksum). No SDK source changes in this repo—the browser package continues to load Gist through the in-app plugin as before.
> 
> This is an automated release sync tied to [gist-web 3.25.0](https://github.com/customerio/gist-web/releases/tag/3.25.0); behavior changes, if any, live in that upstream package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e20611a83c7237b5f68f1e207ec6ad29c002b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->